### PR TITLE
[Sprint 1][T004] Exposer API POST /games et GET /games/{id}

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,46 @@ curl http://localhost:8080/api/protected \
 }
 ```
 
+### Games
+
+#### Créer une partie
+
+```bash
+curl -X POST http://localhost:8080/games \
+  -H "Authorization: Bearer <access-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"boardSize":19}'
+```
+
+Réponse (HTTP 201):
+```json
+{
+  "gameId": "<uuid>"
+}
+```
+
+#### Lire l'état d'une partie
+
+```bash
+curl http://localhost:8080/games/<game-id> \
+  -H "Authorization: Bearer <access-token>"
+```
+
+Réponse (HTTP 200):
+```json
+{
+  "gameId": "<uuid>",
+  "boardSize": 19,
+  "status": "IN_PROGRESS",
+  "nextPlayer": "BLACK",
+  "moveCount": 0,
+  "createdAt": "2026-06-09T20:00:00Z",
+  "board": [
+    ["EMPTY", "..."]
+  ]
+}
+```
+
 ## Gestion des Erreurs
 
 L'API utilise un format d'erreur standardisé :

--- a/src/main/java/com/appgo/games/controller/GameController.java
+++ b/src/main/java/com/appgo/games/controller/GameController.java
@@ -1,0 +1,38 @@
+package com.appgo.games.controller;
+
+import com.appgo.games.dto.CreateGameRequest;
+import com.appgo.games.dto.CreateGameResponse;
+import com.appgo.games.dto.GameStateResponse;
+import com.appgo.games.service.GameService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/games")
+public class GameController {
+
+    private final GameService gameService;
+
+    public GameController(GameService gameService) {
+        this.gameService = gameService;
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateGameResponse> createGame(@Valid @RequestBody(required = false) CreateGameRequest request) {
+        Integer boardSize = request == null ? null : request.boardSize();
+        CreateGameResponse response = gameService.createGame(boardSize);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{id}")
+    public GameStateResponse getGame(@PathVariable("id") String gameId) {
+        return gameService.getGameById(gameId);
+    }
+}

--- a/src/main/java/com/appgo/games/dto/CreateGameRequest.java
+++ b/src/main/java/com/appgo/games/dto/CreateGameRequest.java
@@ -1,0 +1,10 @@
+package com.appgo.games.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record CreateGameRequest(
+        @Min(value = 5, message = "Board size must be greater than or equal to 5")
+        @Max(value = 25, message = "Board size must be lower than or equal to 25")
+        Integer boardSize) {
+}

--- a/src/main/java/com/appgo/games/dto/CreateGameResponse.java
+++ b/src/main/java/com/appgo/games/dto/CreateGameResponse.java
@@ -1,0 +1,4 @@
+package com.appgo.games.dto;
+
+public record CreateGameResponse(String gameId) {
+}

--- a/src/main/java/com/appgo/games/dto/GameStateResponse.java
+++ b/src/main/java/com/appgo/games/dto/GameStateResponse.java
@@ -1,0 +1,14 @@
+package com.appgo.games.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record GameStateResponse(
+        String gameId,
+        int boardSize,
+        String status,
+        String nextPlayer,
+        int moveCount,
+        Instant createdAt,
+        List<List<String>> board) {
+}

--- a/src/main/java/com/appgo/games/exception/GameNotFoundException.java
+++ b/src/main/java/com/appgo/games/exception/GameNotFoundException.java
@@ -1,0 +1,8 @@
+package com.appgo.games.exception;
+
+public class GameNotFoundException extends RuntimeException {
+
+    public GameNotFoundException(String gameId) {
+        super("Game not found: " + gameId);
+    }
+}

--- a/src/main/java/com/appgo/games/model/GameState.java
+++ b/src/main/java/com/appgo/games/model/GameState.java
@@ -1,0 +1,78 @@
+package com.appgo.games.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class GameState {
+
+    private static final String EMPTY_INTERSECTION = "EMPTY";
+
+    private final String gameId;
+    private final int boardSize;
+    private final Instant createdAt;
+    private final List<List<String>> board;
+    private final String status;
+    private String nextPlayer;
+    private int moveCount;
+
+    private GameState(String gameId, int boardSize, Instant createdAt, List<List<String>> board, String status) {
+        this.gameId = gameId;
+        this.boardSize = boardSize;
+        this.createdAt = createdAt;
+        this.board = board;
+        this.status = status;
+        this.nextPlayer = "BLACK";
+        this.moveCount = 0;
+    }
+
+    public static GameState createNew(int boardSize) {
+        return new GameState(
+                UUID.randomUUID().toString(),
+                boardSize,
+                Instant.now(),
+                buildEmptyBoard(boardSize),
+                "IN_PROGRESS");
+    }
+
+    private static List<List<String>> buildEmptyBoard(int boardSize) {
+        List<List<String>> grid = new ArrayList<>(boardSize);
+        for (int row = 0; row < boardSize; row++) {
+            List<String> line = new ArrayList<>(boardSize);
+            for (int col = 0; col < boardSize; col++) {
+                line.add(EMPTY_INTERSECTION);
+            }
+            grid.add(line);
+        }
+        return grid;
+    }
+
+    public String getGameId() {
+        return gameId;
+    }
+
+    public int getBoardSize() {
+        return boardSize;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public List<List<String>> getBoard() {
+        return board;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getNextPlayer() {
+        return nextPlayer;
+    }
+
+    public int getMoveCount() {
+        return moveCount;
+    }
+}

--- a/src/main/java/com/appgo/games/service/GameService.java
+++ b/src/main/java/com/appgo/games/service/GameService.java
@@ -1,0 +1,49 @@
+package com.appgo.games.service;
+
+import com.appgo.games.dto.CreateGameResponse;
+import com.appgo.games.dto.GameStateResponse;
+import com.appgo.games.exception.GameNotFoundException;
+import com.appgo.games.model.GameState;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class GameService {
+
+    private static final int DEFAULT_BOARD_SIZE = 19;
+
+    private final Map<String, GameState> gamesById = new ConcurrentHashMap<>();
+
+    public CreateGameResponse createGame(Integer requestedBoardSize) {
+        int boardSize = requestedBoardSize == null ? DEFAULT_BOARD_SIZE : requestedBoardSize;
+        GameState game = GameState.createNew(boardSize);
+        gamesById.put(game.getGameId(), game);
+        return new CreateGameResponse(game.getGameId());
+    }
+
+    public GameStateResponse getGameById(String gameId) {
+        GameState game = gamesById.get(gameId);
+        if (game == null) {
+            throw new GameNotFoundException(gameId);
+        }
+        return toResponse(game);
+    }
+
+    private GameStateResponse toResponse(GameState game) {
+        List<List<String>> board = game.getBoard().stream()
+                .map(List::copyOf)
+                .toList();
+
+        return new GameStateResponse(
+                game.getGameId(),
+                game.getBoardSize(),
+                game.getStatus(),
+                game.getNextPlayer(),
+                game.getMoveCount(),
+                game.getCreatedAt(),
+                board);
+    }
+}

--- a/src/main/java/com/appgo/shared/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/appgo/shared/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.appgo.shared.error;
 
+import com.appgo.games.exception.GameNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -60,6 +61,21 @@ public class GlobalExceptionHandler {
                 requestId);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+    }
+
+    @ExceptionHandler(GameNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleGameNotFoundException(GameNotFoundException ex) {
+        String requestId = UUID.randomUUID().toString();
+        log.warn("Resource not found: {}", requestId, ex);
+
+        ErrorResponse response = new ErrorResponse(
+                ErrorCode.NOT_FOUND,
+                ex.getMessage(),
+                LocalDateTime.now(),
+                null,
+                requestId);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/appgo/games/controller/GameControllerTest.java
+++ b/src/test/java/com/appgo/games/controller/GameControllerTest.java
@@ -1,0 +1,102 @@
+package com.appgo.games.controller;
+
+import com.appgo.auth.config.AuthProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class GameControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AuthProperties authProperties;
+
+    @Test
+    void createGameReturnsGameId() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        mockMvc.perform(post("/games")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.gameId").exists());
+    }
+
+    @Test
+    void getGameByIdReturnsStateForExistingGame() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        var createResult = mockMvc.perform(post("/games")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "boardSize": 9
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createBody = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String gameId = createBody.get("gameId").asText();
+
+        mockMvc.perform(get("/games/{id}", gameId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.gameId").value(gameId))
+                .andExpect(jsonPath("$.boardSize").value(9))
+                .andExpect(jsonPath("$.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.nextPlayer").value("BLACK"))
+                .andExpect(jsonPath("$.moveCount").value(0))
+                .andExpect(jsonPath("$.board").isArray())
+                .andExpect(jsonPath("$.board.length()").value(9))
+                .andExpect(jsonPath("$.board[0].length()").value(9))
+                .andExpect(jsonPath("$.board[0][0]").value("EMPTY"));
+    }
+
+    @Test
+    void getGameByIdReturnsNotFoundWhenGameDoesNotExist() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        mockMvc.perform(get("/games/{id}", "unknown-id")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    private String loginAndReadAccessToken() throws Exception {
+        var result = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "%s",
+                                  "password": "%s"
+                                }
+                                """.formatted(authProperties.getDemo().getUsername(), authProperties.getDemo().getPassword())))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        return body.get("accessToken").asText();
+    }
+}


### PR DESCRIPTION
## Résumé\nImplémentation de l'issue #4 pour exposer l'API de création et lecture de partie.\n\n## Changements\n- Ajout de POST /games (création de partie, retour gameId)\n- Ajout de GET /games/{id} (lecture de l'état de partie)\n- Ajout d'une gestion d'erreur 404 NOT_FOUND pour les parties inexistantes\n- Ajout de tests d'intégration GameControllerTest\n- Mise à jour du README avec les endpoints Games\n\n## Validation\n- mvnw.cmd test\n- Résultat : BUILD SUCCESS (10 tests, 0 échec)\n\nCloses #4