### PR TITLE
[Sprint 1][T005] Exposer API POST /games/{id}/moves

### DIFF
--- a/src/main/java/com/appgo/games/controller/GameController.java
+++ b/src/main/java/com/appgo/games/controller/GameController.java
@@ -3,6 +3,7 @@ package com.appgo.games.controller;
 import com.appgo.games.dto.CreateGameRequest;
 import com.appgo.games.dto.CreateGameResponse;
 import com.appgo.games.dto.GameStateResponse;
+import com.appgo.games.dto.MakeMoveRequest;
 import com.appgo.games.service.GameService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -34,5 +35,13 @@ public class GameController {
     @GetMapping("/{id}")
     public GameStateResponse getGame(@PathVariable("id") String gameId) {
         return gameService.getGameById(gameId);
+    }
+
+    @PostMapping("/{id}/moves")
+    public ResponseEntity<GameStateResponse> makeMove(
+            @PathVariable("id") String gameId,
+            @Valid @RequestBody MakeMoveRequest request) {
+        GameStateResponse response = gameService.playMove(gameId, request.row(), request.col());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/appgo/games/dto/MakeMoveRequest.java
+++ b/src/main/java/com/appgo/games/dto/MakeMoveRequest.java
@@ -1,0 +1,15 @@
+package com.appgo.games.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record MakeMoveRequest(
+        @NotNull(message = "Row is required")
+        @Min(value = 0, message = "Row must be >= 0")
+        Integer row,
+
+        @NotNull(message = "Column is required")
+        @Min(value = 0, message = "Column must be >= 0")
+        Integer col
+) {
+}

--- a/src/main/java/com/appgo/games/exception/IllegalMoveException.java
+++ b/src/main/java/com/appgo/games/exception/IllegalMoveException.java
@@ -1,0 +1,12 @@
+package com.appgo.games.exception;
+
+public class IllegalMoveException extends RuntimeException {
+
+    public IllegalMoveException(String message) {
+        super(message);
+    }
+
+    public IllegalMoveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/appgo/games/model/GameState.java
+++ b/src/main/java/com/appgo/games/model/GameState.java
@@ -1,5 +1,8 @@
 package com.appgo.games.model;
 
+import com.appgo.game.domain.CouleurPierre;
+import com.appgo.game.domain.PartieGo;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -8,32 +11,38 @@ import java.util.UUID;
 public class GameState {
 
     private static final String EMPTY_INTERSECTION = "EMPTY";
+    private static final String BLACK_STONE = "BLACK";
+    private static final String WHITE_STONE = "WHITE";
 
     private final String gameId;
     private final int boardSize;
     private final Instant createdAt;
     private final List<List<String>> board;
     private final String status;
+    private final PartieGo partie;
     private String nextPlayer;
     private int moveCount;
 
-    private GameState(String gameId, int boardSize, Instant createdAt, List<List<String>> board, String status) {
+    private GameState(String gameId, int boardSize, Instant createdAt, List<List<String>> board, String status, PartieGo partie) {
         this.gameId = gameId;
         this.boardSize = boardSize;
         this.createdAt = createdAt;
         this.board = board;
         this.status = status;
+        this.partie = partie;
         this.nextPlayer = "BLACK";
         this.moveCount = 0;
     }
 
     public static GameState createNew(int boardSize) {
+        PartieGo partie = new PartieGo(boardSize);
         return new GameState(
                 UUID.randomUUID().toString(),
                 boardSize,
                 Instant.now(),
                 buildEmptyBoard(boardSize),
-                "IN_PROGRESS");
+                "IN_PROGRESS",
+                partie);
     }
 
     private static List<List<String>> buildEmptyBoard(int boardSize) {
@@ -46,6 +55,36 @@ public class GameState {
             grid.add(line);
         }
         return grid;
+    }
+
+    public boolean isMoveLegal(int row, int col) {
+        return partie.estCoupLegal(row, col);
+    }
+
+    public void applyMove(int row, int col) {
+        partie.jouer(row, col);
+        updateBoardFromPartie();
+        moveCount++;
+        nextPlayer = partie.getJoueurCourant() == CouleurPierre.NOIR ? "BLACK" : "WHITE";
+    }
+
+    private void updateBoardFromPartie() {
+        for (int row = 0; row < boardSize; row++) {
+            for (int col = 0; col < boardSize; col++) {
+                CouleurPierre couleur = partie.pierreA(row, col);
+                if (couleur == null) {
+                    board.get(row).set(col, EMPTY_INTERSECTION);
+                } else if (couleur == CouleurPierre.NOIR) {
+                    board.get(row).set(col, BLACK_STONE);
+                } else {
+                    board.get(row).set(col, WHITE_STONE);
+                }
+            }
+        }
+    }
+
+    public PartieGo getPartie() {
+        return partie;
     }
 
     public String getGameId() {

--- a/src/main/java/com/appgo/games/service/GameService.java
+++ b/src/main/java/com/appgo/games/service/GameService.java
@@ -3,6 +3,7 @@ package com.appgo.games.service;
 import com.appgo.games.dto.CreateGameResponse;
 import com.appgo.games.dto.GameStateResponse;
 import com.appgo.games.exception.GameNotFoundException;
+import com.appgo.games.exception.IllegalMoveException;
 import com.appgo.games.model.GameState;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +30,25 @@ public class GameService {
         if (game == null) {
             throw new GameNotFoundException(gameId);
         }
+        return toResponse(game);
+    }
+
+    public GameStateResponse playMove(String gameId, int row, int col) {
+        GameState game = gamesById.get(gameId);
+        if (game == null) {
+            throw new GameNotFoundException(gameId);
+        }
+
+        if (!game.isMoveLegal(row, col)) {
+            throw new IllegalMoveException("Illegal move at position [" + row + ", " + col + "]");
+        }
+
+        try {
+            game.applyMove(row, col);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalMoveException(e.getMessage(), e);
+        }
+
         return toResponse(game);
     }
 

--- a/src/main/java/com/appgo/shared/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/appgo/shared/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.appgo.shared.error;
 
 import com.appgo.games.exception.GameNotFoundException;
+import com.appgo.games.exception.IllegalMoveException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -76,6 +77,21 @@ public class GlobalExceptionHandler {
                 requestId);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(IllegalMoveException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalMoveException(IllegalMoveException ex) {
+        String requestId = UUID.randomUUID().toString();
+        log.warn("Illegal move: {}", requestId, ex);
+
+        ErrorResponse response = new ErrorResponse(
+                ErrorCode.UNPROCESSABLE_ENTITY,
+                ex.getMessage(),
+                LocalDateTime.now(),
+                null,
+                requestId);
+
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/appgo/games/controller/GameControllerTest.java
+++ b/src/test/java/com/appgo/games/controller/GameControllerTest.java
@@ -84,6 +84,148 @@ class GameControllerTest {
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"));
     }
 
+    @Test
+    void makeMoveOnLegalPositionReturns200AndUpdatesBoard() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        var createResult = mockMvc.perform(post("/games")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "boardSize": 9
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createBody = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String gameId = createBody.get("gameId").asText();
+
+        // Make a legal move at (3, 3)
+        var moveResult = mockMvc.perform(post("/games/{id}/moves", gameId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "row": 3,
+                                  "col": 3
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.gameId").value(gameId))
+                .andExpect(jsonPath("$.moveCount").value(1))
+                .andExpect(jsonPath("$.nextPlayer").value("WHITE"))
+                .andExpect(jsonPath("$.board[3][3]").value("BLACK"))
+                .andReturn();
+
+        // Verify the board was updated
+        JsonNode moveBody = objectMapper.readTree(moveResult.getResponse().getContentAsString());
+        String boardValue = moveBody.get("board").get(3).get(3).asText();
+        assert boardValue.equals("BLACK");
+    }
+
+    @Test
+    void makeMoveOnOccupiedPositionReturns422() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        var createResult = mockMvc.perform(post("/games")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "boardSize": 9
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createBody = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String gameId = createBody.get("gameId").asText();
+
+        // Make first move
+        mockMvc.perform(post("/games/{id}/moves", gameId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "row": 3,
+                                  "col": 3
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        // Try to make move at same position
+        mockMvc.perform(post("/games/{id}/moves", gameId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "row": 3,
+                                  "col": 3
+                                }
+                                """))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("UNPROCESSABLE_ENTITY"));
+    }
+
+    @Test
+    void makeMoveOutOfBoundsReturns422() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        var createResult = mockMvc.perform(post("/games")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "boardSize": 9
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createBody = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String gameId = createBody.get("gameId").asText();
+
+        // Try to move out of bounds
+        mockMvc.perform(post("/games/{id}/moves", gameId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "row": 10,
+                                  "col": 10
+                                }
+                                """))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("UNPROCESSABLE_ENTITY"));
+    }
+
+    @Test
+    void makeMoveOnNonExistentGameReturns404() throws Exception {
+        String accessToken = loginAndReadAccessToken();
+
+        mockMvc.perform(post("/games/{id}/moves", "non-existent")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "row": 3,
+                                  "col": 3
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void makeMoveWithoutAuthorizationReturns401() throws Exception {
+        mockMvc.perform(post("/games")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
     private String loginAndReadAccessToken() throws Exception {
         var result = mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Implémentation de l'API pour jouer des coups au Go.

## Changements

- DTO: Creation de MakeMoveRequest pour valider les coordonnées
- Intégration PartieGo: GameState encapsule la logique métier
- Exception: IllegalMoveException mappée à 422
- Service: Méthode playMove() avec validation
- Endpoint: POST /games/{id}/moves
- Tests: 6 tests d'intégration couvrant les cas nominaux et d'erreurs

## Critères d'acceptation

✓ Coup légal → 200 + nouvel état
✓ Coup illégal → 422
✓ Non autorisé → 401
✓ Tests d'intégration nominaux + cas d'erreurs

## Tests

Tous les 21 tests passent (BUILD SUCCESS)

Closes #5